### PR TITLE
Deploy admin user keys first in deployment

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,7 +1,7 @@
 - hosts: servers
   roles:
+    - admin_user
     - apt_common_tools
     - hostname
     - firewall
     - journald
-    - admin_user


### PR DESCRIPTION
In case we have any other issues during deployment, if we install SSH keys first then admin users will have the ability to gain server access to help fix broken deployments